### PR TITLE
fix showing the result when the it is equal to zero

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,7 +37,7 @@ reset.addEventListener('click', () => {
     lastResult = ''
 })
 equal.addEventListener('click', () => {
-    if(eval(input.value)) {
+    if(eval(input.value) != undefined) {
         lastResult = eval(input.value)
         input.value = input.value + ' = ' + lastResult
     }


### PR DESCRIPTION
you check if there is a value to show when the user clicks in the equal button, the `input.value` could be any number ... it could be 0, the `if()` statement ignores the falsy values and **zero 0**  is also a falsy value so it won't show the result ... try to calculate `5 * 0` for example .